### PR TITLE
jproperties 2.1.1 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,57 @@
 {% set name = "jproperties" %}
 {% set version = "2.1.1" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jproperties-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 40b71124e8d257e8954899a91cd2d5c0f72e0f67f1b72048a5ba264567604f29
 
 build:
   number: 0
-  noarch: python
   entry_points:
     - propconv = jproperties:main
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
+    - python
     - pip
-    - setuptools_scm ~= 3.3
-    - python 2.7|>=3.6
+    - setuptools
+    - wheel
+    - setuptools_scm ~=3.3
   run:
-    - python 2.7|>=3.6
+    - python
     - six ~=1.13
 
 test:
   imports:
     - jproperties
-  commands:
-    - pip check
   requires:
     - pip
+    - pytest
+  source_files:
+    - tests
+  commands:
+    - pip check
+    # skip test_simple_utf8_load_write_file because it needs conftest.py
+    # that is not in the tarball for a fixture
+    - pytest -v tests/ -k "not test_simple_utf8_load_write_file"
 
 about:
   home: https://github.com/Tblue/python-jproperties
-  summary: Java Property file parser and writer for Python
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
+  summary: Java Property file parser and writer for Python
+  description: |
+    jProperties is a Java Property file parser and writer for Python.
+    It aims to provide the same functionality as Java's Properties class, 
+    although currently the XML property format is not supported.
+  dev_url: https://github.com/Tblue/python-jproperties
+  doc_url: https://github.com/Tblue/python-jproperties/blob/v{{ version }}/README.rst
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
jproperties 2.1.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3929]
- dev_url: https://github.com/Tblue/python-jproperties/tree/v2.1.1
- conda-forge: https://github.com/conda-forge/jproperties-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/jproperties
- inspector: https://inspector.pypi.io/project/jproperties/2.1.1/

### Explanation of changes:

- add abs, recipe, add upstream tests (skip one that requires conftest.py that is not included in the tarball)


[PKG-3929]: https://anaconda.atlassian.net/browse/PKG-3929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ